### PR TITLE
added new apriltag lcm msg for mbot_apriltag use

### DIFF
--- a/mbot_lcm_serial/include/mbot_lcm_serial/lcm_config.h
+++ b/mbot_lcm_serial/include/mbot_lcm_serial/lcm_config.h
@@ -17,6 +17,7 @@
 #define MBOT_IMU_CHANNEL "MBOT_IMU"
 #define MBOT_ENCODERS_CHANNEL "MBOT_ENCODERS"
 #define MBOT_ENCODERS_RESET_CHANNEL "MBOT_ENCODERS_RESET"
+#define MBOT_APRILTAG_ARRAY_CHANNEL "MBOT_APRILTAG_ARRAY"
 
 /////// serial channels //////
 enum message_topics{
@@ -31,7 +32,8 @@ enum message_topics{
     MBOT_MOTOR_VEL_CMD = 231,
     MBOT_MOTOR_VEL = 232,
     MBOT_MOTOR_PWM = 233,
-    MBOT_VEL = 234
+    MBOT_VEL = 234,
+    MBOT_APRILTAG_ARRAY = 235
 };
 
 #endif // LCM_CONFIG_H

--- a/mbot_msgs/CMakeLists.txt
+++ b/mbot_msgs/CMakeLists.txt
@@ -42,6 +42,8 @@ set(LCM_FILES
       lcmtypes/slam_status_t.lcm
       lcmtypes/exploration_status_t.lcm
       lcmtypes/planner_request_t.lcm
+      lcmtypes/mbot_apriltag_t.lcm
+      lcmtypes/mbot_apriltag_array_t.lcm
 )
 
 lcm_wrap_types(

--- a/mbot_msgs/lcmtypes/mbot_apriltag_array_t.lcm
+++ b/mbot_msgs/lcmtypes/mbot_apriltag_array_t.lcm
@@ -1,0 +1,8 @@
+package mbot_lcm_msgs;
+
+struct mbot_apriltag_array_t
+{
+    int64_t utime;
+    int32_t array_size;
+    mbot_apriltag_t detections[array_size]; 
+}

--- a/mbot_msgs/lcmtypes/mbot_apriltag_t.lcm
+++ b/mbot_msgs/lcmtypes/mbot_apriltag_t.lcm
@@ -1,0 +1,7 @@
+package mbot_lcm_msgs;
+
+struct mbot_apriltag_t
+{
+    int32_t tag_id;
+    pose3D_t pose;
+}


### PR DESCRIPTION
Added 2 apriltag lcm messages for [mbot_apriltag](https://github.com/MBot-Project-Development/mbot_apriltag/tree/main).

There is only lcm msg added to the codebase, the change is backward-compatible, should not cause any issues for other users.